### PR TITLE
Fix bug in final `eval_if` branch in iterator_category_to_traversal.h metafunctions

### DIFF
--- a/thrust/iterator/detail/iterator_category_to_traversal.h
+++ b/thrust/iterator/detail/iterator_category_to_traversal.h
@@ -48,7 +48,7 @@ template <typename Category>
               eval_if<
                 is_convertible<Category, output_host_iterator_tag>::value,
                 detail::identity_<incrementable_traversal_tag>,
-                void
+                detail::identity_<void>
               >
             >
           >
@@ -76,7 +76,7 @@ template <typename Category>
               eval_if<
                 is_convertible<Category, output_device_iterator_tag>::value,
                 detail::identity_<incrementable_traversal_tag>,
-                void
+                detail::identity_<void>
               >
             >
           >
@@ -107,7 +107,7 @@ template<typename Category>
           device_system_category_to_traversal<Category>,
 
           // unknown category
-          void
+          detail::identity_<void>
         >
       >
 {};


### PR DESCRIPTION
Whether this is actually a bug or not depends on intent: if the intent is to force a hard error if we reach the final `eval_if` branch, then the code is correct as-is. If, however, the intent is for the metafunctions to evaluate to `void` as I suspect, then this is a bug.